### PR TITLE
docs: add proprietary license defining copyright and usage restrictions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+Copyright (c) 2026 Incubadora de Negócios de Impacto (IFPR Campus Paranaguá)
+
+All rights reserved.
+
+This repository contains proprietary source code and related assets.
+Unauthorized copying, modification, distribution, or use of this software,
+in whole or in part, is strictly prohibited without prior written permission
+from the copyright holder.


### PR DESCRIPTION
- Introduced a proprietary LICENSE file with "All rights reserved" to clarify that the repository is public but the source code is not open source and cannot be copied, modified, or distributed without permission.